### PR TITLE
'in' Filters with too many elements fail with "Uncaught RangeError"

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,8 +33,8 @@ var operators = {
     '>=': strictInfix('>='),
     'in': function(_, key) {
         return '(function(){' + Array.prototype.slice.call(arguments, 2).map(function(value) {
-                return 'if (' + operators['=='](_, key, value) + ') return true;';
-            }).join('') + 'return false;})()';
+            return 'if (' + operators['=='](_, key, value) + ') return true;';
+        }).join('') + 'return false;})()';
     },
     '!in': function() {
         return '!(' + operators.in.apply(this, arguments) + ')';

--- a/index.js
+++ b/index.js
@@ -32,9 +32,9 @@ var operators = {
     '<=': strictInfix('<='),
     '>=': strictInfix('>='),
     'in': function(_, key) {
-        return '[' + Array.prototype.slice.call(arguments, 2).map(function(value) {
-            return '(' + operators['=='](_, key, value) + ')';
-        }).join(',') + '].indexOf(true) >= 0';
+        return '(function(){' + Array.prototype.slice.call(arguments, 2).map(function(value) {
+                return 'if (' + operators['=='](_, key, value) + ') return true;';
+            }).join('') + 'return false;})()';
     },
     '!in': function() {
         return '!(' + operators.in.apply(this, arguments) + ')';

--- a/index.js
+++ b/index.js
@@ -32,9 +32,12 @@ var operators = {
     '<=': strictInfix('<='),
     '>=': strictInfix('>='),
     'in': function(_, key) {
-        return Array.prototype.slice.call(arguments, 2).map(function(value) {
-            return '(' + operators['=='](_, key, value) + ')';
-        }).join('||') || 'false';
+        return (key==='$type')?
+            Array.prototype.slice.call(arguments, 2).map(function(value) {
+                return '(' + operators['=='](_, key, value) + ')';
+            }).join('||') || 'false'
+            :
+            JSON.stringify(Array.prototype.slice.call(arguments, 2))+'.indexOf(p['+JSON.stringify(key)+'])>=0';
     },
     '!in': function() {
         return '!(' + operators.in.apply(this, arguments) + ')';

--- a/index.js
+++ b/index.js
@@ -32,12 +32,9 @@ var operators = {
     '<=': strictInfix('<='),
     '>=': strictInfix('>='),
     'in': function(_, key) {
-        return (key==='$type')?
-            Array.prototype.slice.call(arguments, 2).map(function(value) {
-                return '(' + operators['=='](_, key, value) + ')';
-            }).join('||') || 'false'
-            :
-            JSON.stringify(Array.prototype.slice.call(arguments, 2))+'.indexOf(p['+JSON.stringify(key)+'])>=0';
+        return '[' + Array.prototype.slice.call(arguments, 2).map(function(value) {
+            return '(' + operators['=='](_, key, value) + ')';
+        }).join(',') + '].indexOf(true) >= 0';
     },
     '!in': function() {
         return '!(' + operators.in.apply(this, arguments) + ')';

--- a/test.js
+++ b/test.js
@@ -225,6 +225,15 @@ test('in, multiple', function(t) {
     t.end();
 });
 
+test('in, large_multiple', function(t) {
+    var f = filter(['in', 'foo'].concat(Array.apply(null, {length: 2000}).map(Number.call, Number)));
+    t.equal(f({properties: {foo: 0}}), true);
+    t.equal(f({properties: {foo: 1}}), true);
+    t.equal(f({properties: {foo: 1999}}), true);
+    t.equal(f({properties: {foo: 2000}}), false);
+    t.end();
+});
+
 test('in, $type', function(t) {
     var f = filter(['in', '$type', 'LineString', 'Polygon']);
     t.equal(f({type: 1}), false);
@@ -263,6 +272,15 @@ test('!in, multiple', function(t) {
     t.equal(f({properties: {foo: 0}}), false);
     t.equal(f({properties: {foo: 1}}), false);
     t.equal(f({properties: {foo: 3}}), true);
+    t.end();
+});
+
+test('!in, large_multiple', function(t) {
+    var f = filter(['!in', 'foo'].concat(Array.apply(null, {length: 2000}).map(Number.call, Number)));
+    t.equal(f({properties: {foo: 0}}), false);
+    t.equal(f({properties: {foo: 1}}), false);
+    t.equal(f({properties: {foo: 1999}}), false);
+    t.equal(f({properties: {foo: 2000}}), true);
     t.end();
 });
 


### PR DESCRIPTION
Fixes https://github.com/mapbox/mapbox-gl-js/issues/1782

If too many elements (varies by environment, but appx 1-2k) are used for an 'in' filter, it will fail with "Uncaught RangeError: Maximum call stack size exceeded".  This is because the logical comparison of many infix comarisons (eg "(p['foo']==='bar') || (p['foo']==='cat') || ...") becomes too long for the v8natives to handle.

Note: this fix does not handle large lists of VectorTileFeatureTypes.