### PR TITLE
Fix an issue where 'in' '$type' drops features

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ function compare(key, val, op, checkType) {
     return (checkType ? 'typeof ' + left + '=== typeof ' + right + '&&' : '') + left + op + right;
 }
 function compileIn(key, values) {
-    if (key === '$type') values = values.map(types.indexOf.bind(types));
+    if (key === '$type') values = values.map(function(value) { return types.indexOf(value); });
     var left = JSON.stringify(values.sort(compareFn));
     var right = valueExpr(key);
 

--- a/test.js
+++ b/test.js
@@ -239,6 +239,12 @@ test('in, $type', function(t) {
     t.equal(f({type: 1}), false);
     t.equal(f({type: 2}), true);
     t.equal(f({type: 3}), true);
+
+    var f1 = filter(['in', '$type', 'Polygon', 'LineString', 'Point']);
+    t.equal(f1({type: 1}), true);
+    t.equal(f1({type: 2}), true);
+    t.equal(f1({type: 3}), true);
+
     t.end();
 });
 


### PR DESCRIPTION
If 'Point' is listed inside an 'in' facet on the '$type' property as the
last value when all geometry types are listed, it will be ignored.

`indexOf` accepts multiples params and `map` emits multiple params. Only
the first param from map should be passed to indexOf. The order of 'Point'
in the arrays ends up causing the value not to be found and the index in
the compiled filter to be -1.

Using a proper inline function solves the issue.